### PR TITLE
Fix FacebookPhotoImport

### DIFF
--- a/lib/Import/FacebookPhotoImport.php
+++ b/lib/Import/FacebookPhotoImport.php
@@ -125,7 +125,10 @@ class FacebookPhotoImport {
                     $this->deleteEvent(); 
                      
                     throw new \InvalidArgumentException(''); 
-                } 
+                }
+                else {
+                    throw $e;
+                }
             }
             
             if ($response->getStatusCode() !== 200) {


### PR DESCRIPTION
There were some issues with FacebookPhotoImport that were fixed in this pull request:

1. The importer now handles Guzzle Client Exceptions.
2. It removes from the db events that were deleted from Facebook, since we cannot import photos and other data from these events. 
3. In the function that tries to find the album with a similar name to the one of the event, it now breaks out of the loop that iterates through the list of albums when reaching an album older than the start date of the event. There is no possibility for photos from older events with similar name to appear on the page as photos from the current one.